### PR TITLE
fix: Temporarily disable missing icon resources to complete build

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,9 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        <!-- android:icon="@mipmap/ic_launcher" -->
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        <!-- android:roundIcon="@mipmap/ic_launcher_round" -->
         android:supportsRtl="true"
         android:theme="@style/Theme.MeditationApp">
         <activity


### PR DESCRIPTION
- I commented out `android:icon` and `android:roundIcon` attributes in `app/src/main/AndroidManifest.xml`.
- This is a temporary workaround to resolve the build failure caused by missing `mipmap/ic_launcher` and `mipmap/ic_launcher_round` resources.
- Actual app icons should be added to the `res/mipmap-*` directories and these attributes should be uncommented in the future.

This change, combined with previous fixes (resolving AndroidManifest package attribute, ensuring build.gradle namespace, removing placeholder Gemini library, commenting out its code, configuring GitHub Actions, and updating Gradle for CI API key handling), should allow the Android build to pass the resource processing stage.

The remaining known build failure ("SDK location not found") is an environment-specific issue expected to be resolved when running within the GitHub Actions CI environment where the Android SDK is properly set up by the workflow.