### PR TITLE
fix: Resolve AndroidManifest.xml parsing error by removing icon lines

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,9 +6,7 @@
 
     <application
         android:allowBackup="true"
-        <!-- android:icon="@mipmap/ic_launcher" -->
         android:label="@string/app_name"
-        <!-- android:roundIcon="@mipmap/ic_launcher_round" -->
         android:supportsRtl="true"
         android:theme="@style/Theme.MeditationApp">
         <activity


### PR DESCRIPTION
- I completely removed the `android:icon` and `android:roundIcon` attribute lines from `app/src/main/AndroidManifest.xml`.
- This resolves the XML parsing error that occurred during the `processDebugMainManifest` task.
- This is a continuation of temporarily addressing missing icon resources to allow the build to pass. Actual app icons should be added later and the attributes restored.

This change, combined with all previous fixes (resolving AndroidManifest package attribute, ensuring build.gradle namespace, removing placeholder Gemini library, commenting out its code, configuring GitHub Actions, updating Gradle for CI API key handling, and initially commenting out then removing icon lines), should now allow the Android build to pass all manifest and resource processing stages.

The remaining known build failure ("SDK location not found") is an environment-specific issue expected to be resolved when running within the GitHub Actions CI environment where the Android SDK is properly set up by the workflow.