### PR TITLE
fix: Adjust guide text layout and implement Korean TTS

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,17 +23,19 @@
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
         android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginBottom="24dp"
         android:textAlignment="center"
         android:textSize="18sp"
         android:padding="10dp"
         android:minLines="3"
+        android:maxLines="7"
+        android:ellipsize="end"
         android:text="명상 가이드가 여기에 표시됩니다."
         app:layout_constraintTop_toBottomOf="@id/previewView"
         app:layout_constraintBottom_toTopOf="@id/bottomControlsContainer"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.1" />
+        app:layout_constraintVertical_bias="0.2" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/bottomControlsContainer"


### PR DESCRIPTION
This commit addresses your feedback regarding UI overlap and audio guidance:

1.  **Adjust `textViewGuide` Layout:**
    - Modified `app/src/main/res/layout/activity_main.xml`.
    - Changed `app:layout_constraintVertical_bias` for `textViewGuide` to `0.2` to position it higher.
    - Increased `android:layout_marginBottom` to `24dp` for more clearance.
    - Added `android:maxLines="7"` and `android:ellipsize="end"` to better handle longer guide texts and prevent overlap with bottom controls.

2.  **Implement Text-to-Speech (TTS) for Korean Guide:**
    - Modified `MainActivity.kt` to use Android's TextToSpeech engine.
    - TTS is initialized for Korean (with fallback to default language).
    - The displayed Korean meditation guide text (for start, finish, and initial prompt reset) is now spoken by the TTS engine.
    - TTS is properly managed throughout the activity lifecycle (start, stop, shutdown, language changes).

3.  **Remove Placeholder Audio Playback:**
    - Removed the previous mechanism that played a placeholder `.mp3` file (`korean_meditation_guide.mp3`) for the Korean guide.
    - Deleted the placeholder audio file from `app/src/main/res/raw/`.

These changes improve the UI by resolving text overlap and enhance the Korean meditation experience by providing spoken guidance using TTS.