### PR TITLE
fix: Add default string resources for timed meditation guide

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,11 @@
         <item>ko</item>
     </string-array>
     <string name="meditation_finished_toast">Meditation finished.</string>
+    <string name="guide_kor_0_3_min">0-3 min: Settling in. Find a comfortable position, straighten your back, and gently close your eyes or lower your gaze.</string>
+    <string name="guide_kor_3_7_min">3-7 min: Body awareness. Gently bring your attention to the sensations in your body, scanning from head to toe. Notice any tension or warmth without judgment.</string>
+    <string name="guide_kor_7_12_min">7-12 min: Breath observation. Notice the natural rhythm of your breath. Feel the air entering and leaving your body. If your mind wanders, gently return your focus to your breath.</string>
+    <string name="guide_kor_12_17_min">12-17 min: Observing thoughts and feelings. Acknowledge any thoughts or emotions that arise without getting carried away by them. Observe them like clouds passing in the sky.</string>
+    <string name="guide_kor_17_23_min">17-23 min: Self-compassion. Offer yourself some kind words. 'I am doing my best.' 'May I be peaceful.' Embrace yourself with gentle acceptance.</string>
+    <string name="guide_kor_23_27_min">23-27 min: Returning to the body. Gently bring your awareness back to the physical sensations. Feel the contact with the floor or chair. Wiggle your fingers and toes.</string>
+    <string name="guide_kor_27_30_min">27-30 min: Concluding meditation. Gently open your eyes. Carry this sense of calm with you. Thank yourself for this time.</string>
 </resources>


### PR DESCRIPTION
This commit resolves a build failure caused by missing default string resources. The timed meditation guide strings (e.g., `guide_kor_0_3_min`, etc.) were previously only defined in `values-ko/strings.xml`.

Added corresponding string resources with English placeholder text to the default `values/strings.xml` file. This ensures that the Android build system can find default versions for all resources, satisfying the requirement for localized resources and resolving the "unresolved reference" compilation errors in `MainActivity.kt`.