### PR TITLE
fix: Escape apostrophes in default string resource

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="guide_kor_3_7_min">3-7 min: Body awareness. Gently bring your attention to the sensations in your body, scanning from head to toe. Notice any tension or warmth without judgment.</string>
     <string name="guide_kor_7_12_min">7-12 min: Breath observation. Notice the natural rhythm of your breath. Feel the air entering and leaving your body. If your mind wanders, gently return your focus to your breath.</string>
     <string name="guide_kor_12_17_min">12-17 min: Observing thoughts and feelings. Acknowledge any thoughts or emotions that arise without getting carried away by them. Observe them like clouds passing in the sky.</string>
-    <string name="guide_kor_17_23_min">17-23 min: Self-compassion. Offer yourself some kind words. 'I am doing my best.' 'May I be peaceful.' Embrace yourself with gentle acceptance.</string>
+    <string name="guide_kor_17_23_min">17-23 min: Self-compassion. Offer yourself some kind words. \'I am doing my best.\' \'May I be peaceful.\' Embrace yourself with gentle acceptance.</string>
     <string name="guide_kor_23_27_min">23-27 min: Returning to the body. Gently bring your awareness back to the physical sensations. Feel the contact with the floor or chair. Wiggle your fingers and toes.</string>
     <string name="guide_kor_27_30_min">27-30 min: Concluding meditation. Gently open your eyes. Carry this sense of calm with you. Thank yourself for this time.</string>
 </resources>


### PR DESCRIPTION
This commit corrects an "Invalid unicode escape sequence" error that occurred during the Gradle build process.

The error was caused by unescaped apostrophes in the English placeholder text for the `guide_kor_17_23_min` string resource within `app/src/main/res/values/strings.xml`.

Apostrophes in the affected string have been properly escaped using backslashes (e.g., \') to ensure correct XML parsing and resource compilation.